### PR TITLE
Fix CI: create ~/.local/bin before actionlint install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
 
       - name: Install actionlint
         run: |
+          mkdir -p "$HOME/.local/bin"
           curl -sL "$(curl -sL https://api.github.com/repos/rhysd/actionlint/releases/latest \
             | jq -r '.assets[] | select(.name | test("linux_amd64.*tar.gz")) | .browser_download_url')" \
             | tar xz -C "$HOME/.local/bin" actionlint


### PR DESCRIPTION
## Summary
- The "Install actionlint" CI step fails because `$HOME/.local/bin` doesn't exist on GitHub Actions runners
- `tar` exits with code 2: `Cannot open: No such file or directory`, which cascades and cancels all matrix jobs
- Fix: add `mkdir -p "$HOME/.local/bin"` before the `curl`/`tar` extraction

## Test plan
- [x] Verify CI passes on this PR (all 3 Python versions + actionlint job)

Co-authored-by: Claude <noreply@anthropic.com>